### PR TITLE
Add Dev Container setup and upgrade to .NET 10 / Android 36

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+# Base: official MS devcontainers image — .NET 10 LTS on Ubuntu 24.04 (Noble)
+# Already contains: dotnet 10 SDK, git, curl, sudo, "vscode" user (UID 1000)
+FROM mcr.microsoft.com/devcontainers/dotnet:2-10.0-noble
+
+# ── 1. System packages ────────────────────────────────────────────────────────
+# openjdk-21       : Java 21 LTS — required by sdkmanager and Android build-tools
+# unzip            : extract Android cmdline-tools zip
+# libgl1           : emulator OpenGL software renderer (Swiftshader)
+# libpulse0        : emulator audio
+# libc6-i386/lib32z1 : 32-bit deps for some emulator binaries
+# libncurses5      : required by some Android SDK binaries
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+        openjdk-21-jdk-headless \
+        unzip \
+        libgl1 \
+        libpulse0 \
+        libglu1-mesa \
+        libc6-i386 \
+        lib32z1 \
+        libstdc++6 \
+        libncurses5 \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── 2. Java environment ───────────────────────────────────────────────────────
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# ── 3. Android SDK directory layout ──────────────────────────────────────────
+# sdkmanager REQUIRES cmdline-tools at: $ANDROID_HOME/cmdline-tools/latest/
+# Any other path causes "Warning: Could not create settings" and sdkmanager exits.
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${PATH}"
+
+# ── 4. Android cmdline-tools ──────────────────────────────────────────────────
+# Pin version for reproducibility. Check latest at:
+# https://developer.android.com/studio#command-line-tools-only
+ARG CMDLINE_TOOLS_VERSION=13114758
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && curl -fsSL \
+       "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip" \
+       -o /tmp/cmdline-tools.zip \
+    && unzip -q /tmp/cmdline-tools.zip -d /tmp/cmdline-tools-extract \
+    && mv /tmp/cmdline-tools-extract/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest \
+    && rm -rf /tmp/cmdline-tools.zip /tmp/cmdline-tools-extract
+
+# ── 5. Android SDK packages ───────────────────────────────────────────────────
+# API 36 = Android 16 (stable since March 2025) — matches net10.0-android
+# google_apis image (not google_apis_playstore) allows root adb for debugger
+RUN yes | sdkmanager --licenses > /dev/null 2>&1 \
+    && sdkmanager --install \
+        "platforms;android-36" \
+        "build-tools;36.0.0" \
+        "platform-tools" \
+        "emulator" \
+        "system-images;android-36;google_apis;x86_64"
+
+# Fix permissions so vscode user can read the SDK
+RUN chmod -R o+rX ${ANDROID_HOME}
+
+# ── 6. MAUI Android workload ──────────────────────────────────────────────────
+# Installed as root into /usr/share/dotnet — baked into the image layer.
+# --skip-sign-check avoids NuGet signature validation failures in Docker builds.
+RUN dotnet workload install maui-android --skip-sign-check

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,65 @@
+{
+    "name": "MAUI Memory (Android)",
+
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+
+    "workspaceFolder": "/workspaces/maui-memory",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/maui-memory,type=bind,consistency=cached",
+
+    // ── Container runtime arguments ───────────────────────────────────────────
+    "runArgs": [
+        // Pass /dev/kvm for hardware-accelerated Android emulator.
+        // Without this the emulator falls back to software mode and is unusably slow.
+        "--device=/dev/kvm",
+        // Allow the emulator's internal hypervisor to create nested VMs.
+        "--cap-add=KVM",
+        // Needed for the emulator's internal networking (runs its own DHCP).
+        "--cap-add=NET_ADMIN",
+        // Avoids bind-mount permission errors on SELinux hosts.
+        "--security-opt=label=disable"
+    ],
+
+    "containerEnv": {
+        "ANDROID_HOME": "/opt/android-sdk",
+        "ANDROID_SDK_ROOT": "/opt/android-sdk",
+        // Use Swiftshader (software OpenGL) — no GPU passthrough in the container.
+        "ANDROID_EMULATOR_USE_SYSTEM_LIBS": "1"
+    },
+
+    // 5554: emulator console, 5555: ADB over TCP
+    // Lets you run `adb connect localhost:5555` from the host if needed.
+    "forwardPorts": [5554, 5555],
+    "portsAttributes": {
+        "5554": { "label": "Android Emulator Console", "onAutoForward": "silent" },
+        "5555": { "label": "ADB over TCP", "onAutoForward": "silent" }
+    },
+
+    // Creates the default AVD on first container creation (idempotent).
+    "postCreateCommand": "bash .devcontainer/setup.sh",
+
+    // Fixes /dev/kvm permissions inside the container on every start.
+    // Works on any host regardless of kvm group GID — only affects the container.
+    "postStartCommand": "sudo chmod a+rw /dev/kvm 2>/dev/null || true",
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csdevkit",
+                "ms-dotnettools.dotnet-maui",
+                "ms-dotnettools.csharp",
+                "redhat.vscode-xml",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode-remote.remote-containers"
+            ],
+            "settings": {
+                "dotnet.defaultSolution": "maui-memory.slnx",
+                "dotnetAndroidSdk.androidSdkDirectory": "/opt/android-sdk",
+                "java.home": "/usr/lib/jvm/java-21-openjdk-amd64",
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# .devcontainer/setup.sh
+# Post-create: creates a default Android API 36 AVD for MAUI debugging.
+# Idempotent — safe to re-run (skips creation if AVD already exists).
+
+set -euo pipefail
+
+AVD_NAME="maui_api36"
+API_LEVEL="36"
+
+echo "==> Checking for AVD: ${AVD_NAME}"
+
+if avdmanager list avd | grep -q "Name: ${AVD_NAME}"; then
+    echo "    AVD '${AVD_NAME}' already exists — skipping creation."
+else
+    echo "==> Creating AVD '${AVD_NAME}' (API ${API_LEVEL}, x86_64)..."
+    echo "no" | avdmanager create avd \
+        --name "${AVD_NAME}" \
+        --package "system-images;android-${API_LEVEL};google_apis;x86_64" \
+        --device "pixel_6" \
+        --force
+    echo "==> AVD created."
+fi
+
+# Patch hardware config for headless KVM operation (no GPU passthrough in container)
+HARDWARE_CONFIG="${HOME}/.android/avd/${AVD_NAME}.avd/config.ini"
+
+if [ -f "${HARDWARE_CONFIG}" ]; then
+    echo "==> Patching AVD hardware config..."
+
+    # Software OpenGL renderer — no GPU passthrough inside the container
+    if grep -q "^hw.gpu.mode=" "${HARDWARE_CONFIG}"; then
+        sed -i 's/^hw.gpu.mode=.*/hw.gpu.mode=swiftshader_indirect/' "${HARDWARE_CONFIG}"
+    else
+        echo "hw.gpu.mode=swiftshader_indirect" >> "${HARDWARE_CONFIG}"
+    fi
+
+    # Disable snapshots to avoid stale state across container restarts
+    if grep -q "^snapshot.present=" "${HARDWARE_CONFIG}"; then
+        sed -i 's/^snapshot.present=.*/snapshot.present=no/' "${HARDWARE_CONFIG}"
+    else
+        echo "snapshot.present=no" >> "${HARDWARE_CONFIG}"
+    fi
+
+    echo "==> Hardware config patched."
+fi
+
+echo ""
+echo "========================================================"
+echo "  Dev container ready. To start the Android emulator:"
+echo ""
+echo "    emulator -avd ${AVD_NAME} -no-window -no-audio \\"
+echo "             -gpu swiftshader_indirect &"
+echo ""
+echo "  Wait ~30s, then verify:"
+echo "    adb wait-for-device && adb devices"
+echo ""
+echo "  Then press F5 in VS Code to build, deploy, and debug."
+echo "========================================================"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+    "recommendations": [
+        // .NET development
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp",
+        // .NET MAUI — emulator picker, deploy/debug integration
+        "ms-dotnettools.dotnet-maui",
+        // XML editor for AndroidManifest.xml, .csproj, .xaml files
+        "redhat.vscode-xml",
+        // Docker and Dev Containers support
+        "ms-azuretools.vscode-docker",
+        "ms-vscode-remote.remote-containers"
+    ]
+}

--- a/maui-memory/maui-memory.csproj
+++ b/maui-memory/maui-memory.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-android</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 
@@ -56,7 +56,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Add `.devcontainer/` with Dockerfile, `devcontainer.json`, and `setup.sh` to enable one-click VS Code Dev Container support with a KVM-accelerated Android emulator
- KVM permissions handled dynamically via `postStartCommand` — no hardcoded GIDs, works on any machine
- Add `.vscode/extensions.json` with recommended extensions for the project

## Version upgrades

| Component | Before | After |
|-----------|--------|-------|
| .NET | 9 (STS) | 10 LTS |
| Java | 17 | 21 LTS |
| Android API | 35 | 36 (Android 16) |
| Build-tools | 35.0.0 | 36.0.0 |
| `TargetFrameworks` | `net9.0-android` | `net10.0-android` |
| `Logging.Debug` | 9.0.0 | 10.0.0 |

## Test plan

- [ ] Open repo in VS Code → "Reopen in Container" → image builds without errors
- [ ] `dotnet workload list` inside container shows `maui-android`
- [ ] `sdkmanager --list_installed` shows `platforms;android-36` and `build-tools;36.0.0`
- [ ] `emulator -avd maui_api36 -no-window -no-audio -gpu swiftshader_indirect &` boots successfully
- [ ] `adb devices` shows the emulator
- [ ] `F5` deploys and debugs the app on the emulator